### PR TITLE
refactor: migrate Semgrep results to assessment_data table

### DIFF
--- a/packages/cli/src/registry/tools.json
+++ b/packages/cli/src/registry/tools.json
@@ -455,7 +455,12 @@
           "description": "List available rules",
           "type": "boolean"
         }
-      ]
+      ],
+      "severityMapping": {
+        "ERROR": "Warning",
+        "WARNING": "Information",
+        "INFO": "Hint"
+      }
     }
   ]
 }

--- a/packages/core/src/services/semgrepService.ts
+++ b/packages/core/src/services/semgrepService.ts
@@ -189,8 +189,14 @@ export class SemgrepService {
         const semgrepResult = JSON.parse(result.stdout) as SemgrepResult;
 
         // Save to database if enabled
-        if (this.saveToDatabase && this.dataService && semgrepResult.matches.length > 0) {
-          await this.dataService.storeSemgrepResults(semgrepResult.matches);
+        if (this.saveToDatabase && this.dataService) {
+          await this.dataService.storeSemgrepRun(
+            semgrepResult.matches,
+            filePath, // target is the file being analyzed
+            semgrepResult.stats,
+            undefined, // projectId not available in service layer
+            'semgrep-service'
+          );
         }
 
         return semgrepResult;
@@ -239,8 +245,14 @@ export class SemgrepService {
         const semgrepResult = JSON.parse(result.stdout) as SemgrepResult;
 
         // Save to database if enabled
-        if (this.saveToDatabase && this.dataService && semgrepResult.matches.length > 0) {
-          await this.dataService.storeSemgrepResults(semgrepResult.matches);
+        if (this.saveToDatabase && this.dataService) {
+          await this.dataService.storeSemgrepRun(
+            semgrepResult.matches,
+            dirPath, // target is the directory being analyzed
+            semgrepResult.stats,
+            undefined, // projectId not available in service layer
+            'semgrep-service'
+          );
         }
 
         return semgrepResult;
@@ -289,8 +301,16 @@ export class SemgrepService {
         const semgrepResult = JSON.parse(result.stdout) as SemgrepResult;
 
         // Save to database if enabled
-        if (this.saveToDatabase && this.dataService && semgrepResult.matches.length > 0) {
-          await this.dataService.storeSemgrepResults(semgrepResult.matches);
+        if (this.saveToDatabase && this.dataService) {
+          // Use first target as the target identifier, or join if multiple
+          const target = targets.length === 1 ? targets[0] : targets.join(', ');
+          await this.dataService.storeSemgrepRun(
+            semgrepResult.matches,
+            target,
+            semgrepResult.stats,
+            undefined, // projectId not available in service layer
+            'semgrep-service'
+          );
         }
 
         return semgrepResult;

--- a/packages/core/test/semgrep-service-integration.test.ts
+++ b/packages/core/test/semgrep-service-integration.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SemgrepService } from '../src/services/semgrepService';
+import { DataService } from '../src/data-service';
+import fs from 'fs';
+import path from 'path';
+
+describe('SemgrepService Database Integration', () => {
+  let semgrepService: SemgrepService;
+  let dataService: DataService;
+  let testDbPath: string;
+  let mockRunCommand: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    testDbPath = path.join('/tmp', `test-semgrep-service-${Date.now()}.db`);
+    dataService = new DataService({ dbPath: testDbPath });
+    await dataService.initialize();
+
+    // Create SemgrepService with database enabled
+    semgrepService = new SemgrepService({
+      pythonPath: '/usr/bin/python3',
+      runnerPath: '/mock/path/semgrep-runner.py',
+      rulesDir: '/mock/rules',
+      saveToDatabase: true,
+      dataService: dataService,
+    });
+
+    // Create mock function
+    mockRunCommand = vi.fn();
+    // Replace runCommand method on the instance
+    (semgrepService as any).runCommand = mockRunCommand;
+  });
+
+  afterEach(async () => {
+    await dataService.close();
+    if (fs.existsSync(testDbPath)) {
+      fs.unlinkSync(testDbPath);
+    }
+  });
+
+  it('should store semgrep run when analyzeFile is called with database enabled', async () => {
+    // Mock the runCommand to return successful semgrep output
+    // The stdout contains the JSON that will be parsed as SemgrepResult
+    const mockSemgrepOutput = {
+      success: true,
+      stdout: JSON.stringify({
+        success: true,
+        matches: [
+          {
+            rule_id: 'test.rule.vulnerability',
+            severity: 'ERROR',
+            path: '/test/file.ts',
+            file_path: '/test/file.ts',
+            start_line: 10,
+            end_line: 12,
+            start_column: 5,
+            end_column: 20,
+            message: 'Test vulnerability',
+          },
+        ],
+        errors: [],
+        stats: {
+          total_matches: 1,
+          error_count: 1,
+          warning_count: 0,
+          info_count: 0,
+          files_scanned: 1,
+        },
+      }),
+      stderr: '',
+    };
+
+    // Set up mock to return the output
+    mockRunCommand.mockResolvedValue(mockSemgrepOutput);
+
+    const filePath = '/test/file.ts';
+    const result = await semgrepService.analyzeFile(filePath);
+
+    expect(result).toBeDefined();
+    expect(result.success).toBe(true);
+    expect(result.matches).toHaveLength(1);
+
+    // Verify run was stored in database
+    const assessmentData = await dataService.getAssessmentData(
+      undefined,
+      'semgrep'
+    );
+    expect(assessmentData).toHaveLength(1);
+    expect(assessmentData[0].tool_name).toBe('semgrep');
+    expect(assessmentData[0].data_type).toBe('code-analysis');
+    expect(assessmentData[0].data.target).toBe(filePath);
+    expect(assessmentData[0].data.matches).toHaveLength(1);
+    expect(assessmentData[0].data.matches[0].rule_id).toBe('vulnerability');
+    expect(assessmentData[0].source).toBe('semgrep-service');
+  });
+
+  it('should store semgrep run when analyzeDirectory is called', async () => {
+    const mockSemgrepOutput = {
+      success: true,
+      stdout: JSON.stringify({
+        success: true,
+        matches: [
+          {
+            rule_id: 'test.rule.issue1',
+            severity: 'WARNING',
+            path: '/test/dir/file1.ts',
+            file_path: '/test/dir/file1.ts',
+            start_line: 5,
+            end_line: 5,
+            start_column: 1,
+            end_column: 10,
+            message: 'Issue 1',
+          },
+          {
+            rule_id: 'test.rule.issue2',
+            severity: 'INFO',
+            path: '/test/dir/file2.ts',
+            file_path: '/test/dir/file2.ts',
+            start_line: 15,
+            end_line: 15,
+            start_column: 1,
+            end_column: 5,
+            message: 'Issue 2',
+          },
+        ],
+        errors: [],
+        stats: {
+          total_matches: 2,
+          error_count: 0,
+          warning_count: 1,
+          info_count: 1,
+          files_scanned: 2,
+        },
+      }),
+      stderr: '',
+    };
+
+    // Set up mock to return the output
+    mockRunCommand.mockReset();
+    mockRunCommand.mockResolvedValue(mockSemgrepOutput);
+
+    const dirPath = '/test/dir';
+    const result = await semgrepService.analyzeDirectory(dirPath);
+
+    expect(result).toBeDefined();
+    expect(result.success).toBe(true);
+    expect(result.matches).toHaveLength(2);
+
+    // Verify run was stored
+    const assessmentData = await dataService.getAssessmentData(
+      undefined,
+      'semgrep'
+    );
+    expect(assessmentData).toHaveLength(1);
+    expect(assessmentData[0].data.target).toBe(dirPath);
+    expect(assessmentData[0].data.matches).toHaveLength(2);
+    expect(assessmentData[0].data.stats.files_scanned).toBe(2);
+  });
+
+  it('should not store to database when saveToDatabase is false', async () => {
+    // Create service with database disabled
+    const serviceWithoutDb = new SemgrepService({
+      pythonPath: '/usr/bin/python3',
+      runnerPath: '/mock/path/semgrep-runner.py',
+      rulesDir: '/mock/rules',
+      saveToDatabase: false,
+      dataService: null,
+    });
+    
+    // Mock runCommand for this service too
+    (serviceWithoutDb as any).runCommand = vi.fn();
+
+    const mockSemgrepOutput = {
+      success: true,
+      stdout: JSON.stringify({
+        success: true,
+        matches: [
+          {
+            rule_id: 'test.rule',
+            severity: 'ERROR',
+            path: '/test/file.ts',
+            file_path: '/test/file.ts',
+            start_line: 1,
+            end_line: 1,
+            start_column: 1,
+            end_column: 10,
+            message: 'Test',
+          },
+        ],
+        errors: [],
+        stats: {
+          total_matches: 1,
+          error_count: 1,
+          warning_count: 0,
+          info_count: 0,
+          files_scanned: 1,
+        },
+      }),
+      stderr: '',
+    };
+
+    (serviceWithoutDb as any).runCommand.mockResolvedValue(mockSemgrepOutput);
+
+    await serviceWithoutDb.analyzeFile('/test/file.ts');
+
+    // Verify nothing was stored
+    const assessmentData = await dataService.getAssessmentData(
+      undefined,
+      'semgrep'
+    );
+    expect(assessmentData).toHaveLength(0);
+  });
+
+  it('should normalize rule_id when storing matches', async () => {
+    const mockSemgrepOutput = {
+      success: true,
+      stdout: JSON.stringify({
+        success: true,
+        matches: [
+          {
+            rule_id: 'very.long.rule.path.that.has.many.dots.final-rule-name',
+            severity: 'ERROR',
+            path: '/test/file.ts',
+            file_path: '/test/file.ts',
+            start_line: 10,
+            end_line: 10,
+            start_column: 5,
+            end_column: 15,
+            message: 'Test',
+          },
+        ],
+        errors: [],
+        stats: {
+          total_matches: 1,
+          error_count: 1,
+          warning_count: 0,
+          info_count: 0,
+          files_scanned: 1,
+        },
+      }),
+      stderr: '',
+    };
+
+    mockRunCommand.mockResolvedValue(mockSemgrepOutput);
+
+    await semgrepService.analyzeFile('/test/file.ts');
+
+    // Verify rule_id was normalized
+    const assessmentData = await dataService.getAssessmentData(
+      undefined,
+      'semgrep'
+    );
+    expect(assessmentData[0].data.matches[0].rule_id).toBe('final-rule-name');
+  });
+});
+

--- a/plugins/vscode/src/code-scan-tree-provider.ts
+++ b/plugins/vscode/src/code-scan-tree-provider.ts
@@ -241,54 +241,25 @@ export class CodeScanTreeProvider implements vscode.TreeDataProvider<CodeScanIte
   }
 
   async deleteSemgrepResultsForFiles(items: CodeScanItem[]): Promise<void> {
-    const semgrepDataService = getSemgrepDataService();
-    if (!semgrepDataService) {
-      vscode.window.showErrorMessage("Semgrep database service not available");
-      return;
-    }
-
-    // Extract file paths from selected items
-    const filePaths = items
-      .filter(item => item.type === "file" && item.label)
-      .map(item => {
-        // Convert back to relative path by extracting from absolute path
-        if (item.filePath && this.workspaceFolder) {
-          return vscode.workspace.asRelativePath(item.filePath, false);
-        }
-        return item.label;
-      });
-
-    if (filePaths.length === 0) {
-      vscode.window.showWarningMessage("No Semgrep file results selected");
-      return;
-    }
-
-    const fileList = filePaths.length === 1
-      ? filePaths[0]
-      : `${filePaths.length} files`;
-
-    const answer = await vscode.window.showWarningMessage(
-      `Delete Semgrep results for ${fileList}? This action cannot be undone.`,
-      "Delete",
-      "Cancel"
+    // NOTE: Deletion is currently disabled.
+    // Assessment_data stores runs (not individual file results), so deleting by file path is problematic:
+    // - A run may contain results for multiple files
+    // - Deleting a run would remove results for all files in that run
+    // - We need to decide: delete entire runs containing the file, or filter matches from runs?
+    // 
+    // TODO: Implement proper deletion strategy for assessment_data structure
+    
+    vscode.window.showInformationMessage(
+      "Deletion of Semgrep results is currently disabled. Assessment_data stores runs, not individual file results. Need to implement proper deletion strategy."
     );
-
-    if (answer === "Delete") {
-      try {
-        for (const filePath of filePaths) {
-          await semgrepDataService.deleteSemgrepResultsByFile(filePath);
-        }
-        vscode.window.showInformationMessage(
-          `Deleted Semgrep results for ${fileList}`
-        );
-        // Refresh the tree
-        this.refresh();
-      } catch (error) {
-        vscode.window.showErrorMessage(
-          `Failed to delete Semgrep results: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    }
+    
+    // Disabled deletion code:
+    // const semgrepDataService = getSemgrepDataService();
+    // if (!semgrepDataService) {
+    //   vscode.window.showErrorMessage("Semgrep database service not available");
+    //   return;
+    // }
+    // ... rest of deletion logic
   }
 }
 

--- a/plugins/vscode/src/test/integration/integration.test.ts
+++ b/plugins/vscode/src/test/integration/integration.test.ts
@@ -56,6 +56,9 @@ suite("Carbonara Extension Integration Tests", () => {
       "carbonara.analyzeTool",
       "carbonara.runSemgrep",
       "carbonara.clearSemgrepResults",
+      "carbonara.openSemgrepFile",
+      "carbonara.openSemgrepFinding",
+      "carbonara.deleteSemgrepResultsForFile",
     ];
 
     // Check that all expected commands are registered
@@ -69,7 +72,7 @@ suite("Carbonara Extension Integration Tests", () => {
     // Check that no unexpected commands are registered
     // Filter out VSCode auto-generated tree view commands (.open, .focus, .resetViewLocation, .toggleVisibility, .removeView)
     const vscodeGeneratedSuffixes = ['.open', '.focus', '.resetViewLocation', '.toggleVisibility', '.removeView'];
-    const treeViewPrefixes = ['carbonara.assessmentTree', 'carbonara.dataTree', 'carbonara.toolsTree'];
+    const treeViewPrefixes = ['carbonara.assessmentTree', 'carbonara.dataTree', 'carbonara.toolsTree', 'carbonara.codeScanTree'];
 
     const isVSCodeGeneratedCommand = (cmd: string) => {
       return treeViewPrefixes.some(prefix =>

--- a/plugins/vscode/src/test/integration/semgrep-database-integration.test.ts
+++ b/plugins/vscode/src/test/integration/semgrep-database-integration.test.ts
@@ -1,0 +1,288 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { DataService } from "@carbonara/core";
+
+// Mock the semgrep service to avoid needing actual Semgrep installation
+const mockSemgrepMatches = [
+  {
+    rule_id: "test.rule.security-vulnerability",
+    severity: "ERROR",
+    path: "src/test.ts",
+    file_path: "src/test.ts",
+    start_line: 10,
+    end_line: 12,
+    start_column: 5,
+    end_column: 20,
+    message: "Security vulnerability detected",
+  },
+  {
+    rule_id: "test.rule.performance-issue",
+    severity: "WARNING",
+    path: "src/test.ts",
+    file_path: "src/test.ts",
+    start_line: 25,
+    end_line: 25,
+    start_column: 1,
+    end_column: 10,
+    message: "Performance issue",
+  },
+  {
+    rule_id: "test.rule.code-style",
+    severity: "INFO",
+    path: "src/other.ts",
+    file_path: "src/other.ts",
+    start_line: 5,
+    end_line: 5,
+    start_column: 1,
+    end_column: 5,
+    message: "Code style suggestion",
+  },
+];
+
+suite("Semgrep Database Integration Tests", () => {
+  let testDbPath: string;
+  let dataService: DataService;
+  let mockContext: vscode.ExtensionContext;
+  let testWorkspacePath: string;
+
+  suiteSetup(async function () {
+    // Increase timeout for setup
+    this.timeout(10000);
+    // Create temporary test directory
+    testWorkspacePath = path.join("/tmp", `semgrep-test-${Date.now()}`);
+    fs.mkdirSync(testWorkspacePath, { recursive: true });
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(10000);
+    // Cleanup
+    try {
+      if (testWorkspacePath && fs.existsSync(testWorkspacePath)) {
+        fs.rmSync(testWorkspacePath, { recursive: true, force: true });
+      }
+      if (testDbPath && fs.existsSync(testDbPath)) {
+        fs.unlinkSync(testDbPath);
+      }
+    } catch (error) {
+      // Ignore cleanup errors
+      console.log("Cleanup error (ignored):", error);
+    }
+  });
+
+  setup(async function () {
+    this.timeout(10000);
+    // Create fresh database for each test
+    // Use a unique path in /tmp to avoid conflicts
+    testDbPath = path.join("/tmp", `test-semgrep-${Date.now()}-${Math.random().toString(36).substr(2, 9)}.db`);
+    dataService = new DataService({ dbPath: testDbPath });
+    await dataService.initialize();
+
+    // Create mock workspace folder
+    const testWorkspaceFolder = {
+      uri: vscode.Uri.file(testWorkspacePath),
+      name: "test-workspace",
+      index: 0,
+    };
+
+    // Mock workspace folders
+    Object.defineProperty(vscode.workspace, "workspaceFolders", {
+      value: [testWorkspaceFolder],
+      configurable: true,
+      writable: true,
+    });
+
+    // Create mock context
+    mockContext = {
+      subscriptions: [],
+      workspaceState: {} as any,
+      globalState: {} as any,
+      extensionPath: "/mock/path",
+      extensionUri: vscode.Uri.file("/mock/path"),
+      environmentVariableCollection: {} as any,
+      extensionMode: vscode.ExtensionMode.Test,
+      storageUri: vscode.Uri.file("/mock/storage"),
+      globalStorageUri: vscode.Uri.file("/mock/global-storage"),
+      logUri: vscode.Uri.file("/mock/log"),
+      storagePath: "/mock/storage",
+      globalStoragePath: "/mock/global-storage",
+      logPath: "/mock/log",
+      asAbsolutePath: (p: string) => path.join("/mock/path", p),
+      secrets: {} as any,
+      extension: {} as any,
+      languageModelAccessInformation: {} as any,
+    } as vscode.ExtensionContext;
+  });
+
+  teardown(async function () {
+    this.timeout(5000);
+    try {
+      if (dataService) {
+        await dataService.close();
+      }
+      if (testDbPath && fs.existsSync(testDbPath)) {
+        fs.unlinkSync(testDbPath);
+      }
+    } catch (error) {
+      // Ignore cleanup errors
+      console.log("Teardown error (ignored):", error);
+    }
+  });
+
+  test("should store semgrep run in assessment_data with correct structure", async function () {
+    this.timeout(10000);
+    // Create project
+    const projectId = await dataService.createProject(
+      "Test Project",
+      testWorkspacePath
+    );
+
+    // Store semgrep run (simulating what runSemgrepAnalysis does)
+    const runId = await dataService.storeSemgrepRun(
+      mockSemgrepMatches,
+      "src/test.ts",
+      {
+        total_matches: 3,
+        error_count: 1,
+        warning_count: 1,
+        info_count: 1,
+        files_scanned: 2,
+      },
+      projectId,
+      "vscode-extension"
+    );
+
+    assert.ok(runId > 0, "Run ID should be valid");
+
+    // Verify stored in assessment_data
+    const assessmentData = await dataService.getAssessmentData(
+      projectId,
+      "semgrep"
+    );
+    assert.strictEqual(assessmentData.length, 1, "Should have one run");
+    assert.strictEqual(
+      assessmentData[0].tool_name,
+      "semgrep",
+      "Tool name should be semgrep"
+    );
+    assert.strictEqual(
+      assessmentData[0].data_type,
+      "code-analysis",
+      "Data type should be code-analysis"
+    );
+    assert.strictEqual(
+      assessmentData[0].data.target,
+      "src/test.ts",
+      "Target should match"
+    );
+    assert.strictEqual(
+      assessmentData[0].data.matches.length,
+      3,
+      "Should have 3 matches"
+    );
+    assert.strictEqual(
+      assessmentData[0].data.stats.total_matches,
+      3,
+      "Stats should match"
+    );
+    assert.strictEqual(
+      assessmentData[0].source,
+      "vscode-extension",
+      "Source should be vscode-extension"
+    );
+  });
+
+  test("should retrieve semgrep results by file for code highlighting", async function () {
+    this.timeout(10000);
+    const projectId = await dataService.createProject(
+      "Test Project",
+      testWorkspacePath
+    );
+
+    // Store multiple runs
+    await dataService.storeSemgrepRun(
+      mockSemgrepMatches,
+      "src/test.ts",
+      {
+        total_matches: 3,
+        error_count: 1,
+        warning_count: 1,
+        info_count: 1,
+        files_scanned: 2,
+      },
+      projectId,
+      "vscode-extension"
+    );
+
+    // Get results for specific file (used by code highlighting)
+    const fileResults = await dataService.getSemgrepResultsByFile("src/test.ts");
+
+    assert.strictEqual(
+      fileResults.length,
+      2,
+      "Should have 2 findings for src/test.ts"
+    );
+    assert.ok(
+      fileResults.some((r: any) => r.rule_id === "security-vulnerability"),
+      "Should have security finding"
+    );
+    assert.ok(
+      fileResults.some((r: any) => r.rule_id === "performance-issue"),
+      "Should have performance finding"
+    );
+    assert.strictEqual(
+      fileResults[0].file_path,
+      "src/test.ts",
+      "File path should match"
+    );
+    assert.ok(fileResults[0].created_at, "Should have timestamp");
+  });
+
+  test("should use severity mapping from registry when available", async function () {
+    this.timeout(10000);
+    // Create workspace tools.json with custom severity mapping
+    const toolsJsonPath = path.join(testWorkspacePath, "tools.json");
+    const customMapping = {
+      tools: [
+        {
+          id: "semgrep",
+          name: "Semgrep",
+          severityMapping: {
+            ERROR: "Error", // Map ERROR to Error (more severe)
+            WARNING: "Warning",
+            INFO: "Information",
+          },
+        },
+      ],
+    };
+    fs.writeFileSync(toolsJsonPath, JSON.stringify(customMapping, null, 2));
+
+    // Now test that getSeverityMapping would load this
+    // (We can't directly test the private function, but we can verify the integration)
+    // This test verifies the registry structure is correct
+    const registryContent = fs.readFileSync(toolsJsonPath, "utf8");
+    const registry = JSON.parse(registryContent);
+    const semgrepTool = registry.tools.find((t: any) => t.id === "semgrep");
+
+    assert.ok(semgrepTool, "Should find semgrep tool");
+    assert.ok(
+      semgrepTool.severityMapping,
+      "Should have severity mapping"
+    );
+    assert.strictEqual(
+      semgrepTool.severityMapping.ERROR,
+      "Error",
+      "ERROR should map to Error"
+    );
+    assert.strictEqual(
+      semgrepTool.severityMapping.WARNING,
+      "Warning",
+      "WARNING should map to Warning"
+    );
+
+    // Cleanup
+    fs.unlinkSync(toolsJsonPath);
+  });
+});
+


### PR DESCRIPTION
- Remove deprecated semgrep_results table and storeSemgrepResults method
- Store Semgrep runs in assessment_data table with data_type='code-analysis'
- Add JSON indexing on target_path and total_matches for performance
- Update getSemgrepResultsByFile and getAllSemgrepResults to query assessment_data
- Add severity mapping configuration in tools.json
- Disable deletion by file (requires run-based deletion strategy)
- Add integration tests for Semgrep database operations