### PR TITLE
Reduce the required vscode version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10876,7 +10876,7 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "22.9.0",
-        "@types/vscode": "^1.104.0",
+        "@types/vscode": "^1.76.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.6.2",
         "glob": "^11.0.3",
@@ -10885,7 +10885,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "vscode": "^1.104.0"
+        "vscode": "^1.76.0"
       }
     },
     "plugins/vscode/node_modules/@types/node": {

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -11,7 +11,7 @@
   },
   "license": "To be clarified - All rights reserved",
   "engines": {
-    "vscode": "^1.104.0"
+    "vscode": "^1.76.0"
   },
   "categories": [
     "Other",
@@ -306,7 +306,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "22.9.0",
-    "@types/vscode": "^1.104.0",
+    "@types/vscode": "^1.76.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.6.2",
     "glob": "^11.0.3",


### PR DESCRIPTION
I reduced the required vscode version to an older number, to not force people to have the latest update just to install carbonara...

Which one would be best?

The error was

`Error: Unable to install extension 'carbonara.carbonara-vscode' as it is not compatible with VS Code '1.99.3'.`