### PR TITLE
fix: improve data loading and enable test analyzer e2e test

### DIFF
--- a/packages/core/src/data-service.ts
+++ b/packages/core/src/data-service.ts
@@ -559,6 +559,35 @@ export class DataService {
     this.saveDatabase();
   }
 
+  async reloadDatabase(): Promise<void> {
+    if (!this.SQL) {
+      // If SQL.js isn't initialized, initialize it first
+      await this.initialize();
+      return;
+    }
+
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+
+    // Save current state first
+    this.saveDatabase();
+
+    // Reload from disk
+    let existingData: Buffer | undefined;
+    if (fs.existsSync(this.dbPath)) {
+      existingData = fs.readFileSync(this.dbPath);
+    }
+
+    if (existingData) {
+      // Close old database
+      this.db.close();
+      // Load new database from disk
+      this.db = new this.SQL.Database(existingData);
+    }
+    // If file doesn't exist, keep current in-memory database
+  }
+
   async close(): Promise<void> {
     if (this.db) {
       this.saveDatabase();

--- a/packages/core/src/vscode-data-provider.ts
+++ b/packages/core/src/vscode-data-provider.ts
@@ -36,12 +36,11 @@ export class VSCodeDataProvider {
 
   async loadDataForProject(projectPath: string): Promise<AssessmentDataEntry[]> {
     try {
+      // Try to find project, but don't require it to exist
       const project = await this.dataService.getProject(projectPath);
-      if (!project) {
-        return [];
-      }
-
-      // Load all assessment data (don't filter by project ID)
+      
+      // Load all assessment data regardless of whether project exists
+      // Assessment data can exist without a project record (project_id can be NULL)
       return await this.dataService.getAssessmentData();
     } catch (error) {
       console.error('Failed to load data for project:', error);

--- a/plugins/vscode/src/test/e2e/carbonara-extension.test.ts
+++ b/plugins/vscode/src/test/e2e/carbonara-extension.test.ts
@@ -269,340 +269,340 @@ test.describe("Carbonara VSCode Extension E2E Tests", () => {
     }
   });
 
-  //   test("should show Analysis Tools tree view and allow tool interaction", async () => {
-  //     const vscode = await VSCodeLauncher.launch("with-carbonara-project");
+  test("should show Analysis Tools tree view and allow tool interaction", async () => {
+    const vscode = await VSCodeLauncher.launch("with-carbonara-project");
 
-  //     try {
-  //       // Wait for extension to fully activate
-  //       await VSCodeLauncher.waitForExtension(vscode.window);
+    try {
+      // Wait for extension to fully activate
+      await VSCodeLauncher.waitForExtension(vscode.window);
 
-  //       // Step 1: Open the Carbonara sidebar
+      // Step 1: Open the Carbonara sidebar
 
-  //       await VSCodeLauncher.openSidebar(vscode.window);
+      await VSCodeLauncher.openSidebar(vscode.window);
 
-  //       // Step 2: Assert Analysis Tools section is visible
+      // Step 2: Assert Analysis Tools section is visible
 
-  //       const toolsSection = vscode.window
-  //         .locator(".pane-header")
-  //         .filter({ hasText: "Analysis Tools" });
+      const toolsSection = vscode.window
+        .locator(".pane-header")
+        .filter({ hasText: "Analysis Tools" });
 
-  //       // ASSERTION: Analysis Tools section must be visible
-  //       await expect(toolsSection).toBeVisible({ timeout: 10000 });
+      // ASSERTION: Analysis Tools section must be visible
+      await expect(toolsSection).toBeVisible({ timeout: 10000 });
 
-  //       // Step 3: Check Analysis Tools state and ensure it's expanded
+      // Step 3: Check Analysis Tools state and ensure it's expanded
 
-  //       // Look for the chevron icon to determine current state
-  //       const chevronRight = toolsSection.locator(".codicon-chevron-right"); // Collapsed
-  //       const chevronDown = toolsSection.locator(".codicon-chevron-down"); // Expanded
+      // Look for the chevron icon to determine current state
+      const chevronRight = toolsSection.locator(".codicon-chevron-right"); // Collapsed
+      const chevronDown = toolsSection.locator(".codicon-chevron-down"); // Expanded
 
-  //       const isCollapsed = await chevronRight.isVisible({ timeout: 1000 });
-  //       const isExpanded = await chevronDown.isVisible({ timeout: 1000 });
+      const isCollapsed = await chevronRight.isVisible({ timeout: 1000 });
+      const isExpanded = await chevronDown.isVisible({ timeout: 1000 });
 
-  //       if (isExpanded) {
-  //       } else if (isCollapsed) {
-  //         // Click the chevron icon directly to expand
-  //         await chevronRight.click();
-  //         await vscode.window.waitForTimeout(2000);
+      if (isExpanded) {
+      } else if (isCollapsed) {
+        // Click the chevron icon directly to expand
+        await chevronRight.click();
+        await vscode.window.waitForTimeout(2000);
 
-  //         // Verify it expanded
-  //         const nowExpanded = await chevronDown.isVisible({ timeout: 3000 });
-  //       } else {
-  //         // Don't click anything - might already be in the right state
-  //       }
+        // Verify it expanded
+        const nowExpanded = await chevronDown.isVisible({ timeout: 3000 });
+      } else {
+        // Don't click anything - might already be in the right state
+      }
 
-  //       // Step 4: After clicking, wait for tree content to appear
-  //       await vscode.window.waitForTimeout(1000);
+      // Step 4: After clicking, wait for tree content to appear
+      await vscode.window.waitForTimeout(1000);
 
-  //       // Debug: Check what sections are visible now
-  //       const allSections = vscode.window.locator(".pane-header");
-  //       const sectionCount = await allSections.count();
+      // Debug: Check what sections are visible now
+      const allSections = vscode.window.locator(".pane-header");
+      const sectionCount = await allSections.count();
 
-  //       if (sectionCount > 0) {
-  //         const sectionTexts = await allSections.allTextContents();
-  //       }
+      if (sectionCount > 0) {
+        const sectionTexts = await allSections.allTextContents();
+      }
 
-  //       // Get tools tree using deterministic selector (no fallbacks!)
+      // Get tools tree using deterministic selector (no fallbacks!)
 
-  //       const toolsTree = vscode.window
-  //         .locator(
-  //           '[id*="workbench.view.extension.carbonara"] .monaco-list, [id*="workbench.view.extension.carbonara"] .tree-explorer-viewlet-tree-view'
-  //         )
-  //         .last();
+      const toolsTree = vscode.window
+        .locator(
+          '[id*="workbench.view.extension.carbonara"] .monaco-list, [id*="workbench.view.extension.carbonara"] .tree-explorer-viewlet-tree-view'
+        )
+        .last();
 
-  //       await expect(toolsTree).toBeVisible();
+      await expect(toolsTree).toBeVisible();
 
-  //       const allRows = toolsTree.locator(".monaco-list-row");
+      const allRows = toolsTree.locator(".monaco-list-row");
 
-  //       // Debug: Check what we find in the Analysis Tools section
-  //       const rowCount = await allRows.count();
+      // Debug: Check what we find in the Analysis Tools section
+      const rowCount = await allRows.count();
 
-  //       if (rowCount > 0) {
-  //         const rowTexts = await allRows.allTextContents();
+      if (rowCount > 0) {
+        const rowTexts = await allRows.allTextContents();
 
-  //         // Now we should see either tools or our informative "No analysis tools available" message
-  //         // This helps differentiate between collapsed (no content) vs expanded but no tools
-  //       } else {
-  //       }
+        // Now we should see either tools or our informative "No analysis tools available" message
+        // This helps differentiate between collapsed (no content) vs expanded but no tools
+      } else {
+      }
 
-  //       // Step 6: Verify installed tools (from registry: 1 built-in tool)
+      // Step 6: Verify installed tools (from registry: 1 built-in tool)
 
-  //       const installedTools = toolsTree
-  //         .locator(".monaco-list-row")
-  //         .filter({ hasText: "Built-in" });
+      const installedTools = toolsTree
+        .locator(".monaco-list-row")
+        .filter({ hasText: "Built-in" });
 
-  //       // ASSERTION: Must have exactly 1 installed tool (Test Analyzer in test environment)
-  //       await expect(installedTools).toHaveCount(1, { timeout: 5000 });
+      // ASSERTION: Must have exactly 1 installed tool (Test Analyzer in test environment)
+      await expect(installedTools).toHaveCount(1, { timeout: 5000 });
 
-  //       const installedTexts = await installedTools.allTextContents();
+      const installedTexts = await installedTools.allTextContents();
 
-  //       // ASSERTION: Must be Test Analyzer (test-only tool)
-  //       expect(installedTexts[0]).toContain("Test Analyzer");
+      // ASSERTION: Must be Test Analyzer (test-only tool)
+      expect(installedTexts[0]).toContain("Test Analyzer");
 
-  //       // Step 7: Verify uninstalled tools (from registry: 2 external tools)
+      // Step 7: Verify uninstalled tools (from registry: 2 external tools)
 
-  //       const uninstalledTools = toolsTree
-  //         .locator(".monaco-list-row")
-  //         .filter({ hasText: "Not installed" });
+      const uninstalledTools = toolsTree
+        .locator(".monaco-list-row")
+        .filter({ hasText: "Not installed" });
 
-  //       // ASSERTION: Must have exactly 2 uninstalled tools (GreenFrame + Impact Framework)
-  //       await expect(uninstalledTools).toHaveCount(2, { timeout: 5000 });
+      // ASSERTION: Must have exactly 2 uninstalled tools (GreenFrame + Impact Framework)
+      await expect(uninstalledTools).toHaveCount(2, { timeout: 5000 });
 
-  //       const uninstalledTexts = await uninstalledTools.allTextContents();
+      const uninstalledTexts = await uninstalledTools.allTextContents();
 
-  //       // ASSERTION: Must contain GreenFrame tool
-  //       const hasGreenFrame = uninstalledTexts.some((text) =>
-  //         text.includes("GreenFrame")
-  //       );
-  //       expect(hasGreenFrame).toBe(true);
-
-  //       // ASSERTION: Must contain Impact Framework tool
-  //       const hasImpactFramework = uninstalledTexts.some((text) =>
-  //         text.includes("Impact Framework")
-  //       );
-  //       expect(hasImpactFramework).toBe(true);
-
-  //       // Step 8: Verify total matches registry (1 + 2 = 3 tools)
-  //       const totalTools = await toolsTree.locator(".monaco-list-row").count();
-
-  //       // ASSERTION: Total must be exactly 3 tools from registry
-  //       expect(totalTools).toBe(3);
-
-  //       // Step 9: Test the Test Analyzer functionality
-
-  //       // Click on the Test Analyzer tool to execute it
-  //       const testAnalyzerRow = toolsTree
-  //         .locator(".monaco-list-row")
-  //         .filter({ hasText: "Test Analyzer" });
-  //       await expect(testAnalyzerRow).toBeVisible();
-
-  //       // Click the Test Analyzer row to trigger analysis
-  //       await testAnalyzerRow.click();
+      // ASSERTION: Must contain GreenFrame tool
+      const hasGreenFrame = uninstalledTexts.some((text) =>
+        text.includes("GreenFrame")
+      );
+      expect(hasGreenFrame).toBe(true);
+
+      // ASSERTION: Must contain Impact Framework tool
+      const hasImpactFramework = uninstalledTexts.some((text) =>
+        text.includes("Impact Framework")
+      );
+      expect(hasImpactFramework).toBe(true);
+
+      // Step 8: Verify total matches registry (1 + 2 = 3 tools)
+      const totalTools = await toolsTree.locator(".monaco-list-row").count();
+
+      // ASSERTION: Total must be exactly 3 tools from registry
+      expect(totalTools).toBe(3);
+
+      // Step 9: Test the Test Analyzer functionality
+
+      // Click on the Test Analyzer tool to execute it
+      const testAnalyzerRow = toolsTree
+        .locator(".monaco-list-row")
+        .filter({ hasText: "Test Analyzer" });
+      await expect(testAnalyzerRow).toBeVisible();
+
+      // Click the Test Analyzer row to trigger analysis
+      await testAnalyzerRow.click();
 
-  //       // Wait for URL input dialog to appear
-  //       await vscode.window.waitForTimeout(1000);
-
-  //       // Look for the input box and enter a test URL
-  //       const inputBox = vscode.window.locator(
-  //         'input[placeholder*="https://example.com"], .quick-input-box input'
-  //       );
-  //       await expect(inputBox).toBeVisible({ timeout: 5000 });
-
-  //       const testUrl = "https://test-site.example.com";
-  //       await inputBox.fill(testUrl);
-
-  //       // Press Enter to confirm
-  //       await inputBox.press("Enter");
-
-  //       // Wait for analysis completion notification
-
-  //       // Look for the completion notification or wait longer for CLI to finish
-  //       try {
-  //         // Wait for either success or failure notification using UI constants
-  //         const successNotification = vscode.window
-  //           .locator(SELECTORS.NOTIFICATIONS.TOAST)
-  //           .filter({ hasText: "analysis completed" });
-  //         const failureNotification = vscode.window
-  //           .locator(SELECTORS.NOTIFICATIONS.TOAST)
-  //           .filter({ hasText: UI_TEXT.NOTIFICATIONS.ANALYSIS_FAILED });
-
-  //         // Wait up to 10 seconds for one of these notifications
-  //         await Promise.race([
-  //           successNotification.waitFor({ timeout: 10000 }),
-  //           failureNotification.waitFor({ timeout: 10000 }),
-  //         ]);
-
-  //         // Check which notification appeared
-  //         const hasSuccess = await successNotification.isVisible();
-  //         const hasFailure = await failureNotification.isVisible();
-
-  //         if (hasSuccess) {
-  //         } else if (hasFailure) {
-  //           // FAIL THE TEST: Analysis should succeed for test analyzer
-  //           expect(hasFailure).toBe(false);
-  //           return; // Exit early since analysis failed
-  //         } else {
-  //         }
-
-  //         // ASSERTION: Analysis must succeed (no failure notification should be visible)
-  //         expect(hasFailure).toBe(false);
-  //       } catch (error) {
-  //         // Fallback: wait additional time for CLI process to complete
-  //         await vscode.window.waitForTimeout(3000);
-  //       }
-
-  //       // Step 10: Verify analysis results appear in Data Tree
-
-  //       // Look for the Data & Results section
-  //       const dataSection = vscode.window
-  //         .locator(".pane-header")
-  //         .filter({ hasText: "Data & Results" });
-  //       await expect(dataSection).toBeVisible();
-
-  //       // Click on Data & Results section to ensure it's expanded and active
-  //       await dataSection.click();
-
-  //       // Step 11: Manually refresh the data tree to ensure latest results are loaded
-
-  //       // Use F1 to open command palette and search for data refresh
-  //       await vscode.window.keyboard.press("F1");
-  //       await vscode.window.waitForTimeout(500);
-
-  //       await vscode.window.keyboard.type("Carbonara: Refresh Data");
-  //       await vscode.window.waitForTimeout(500);
-
-  //       await vscode.window.keyboard.press("Enter");
-
-  //       // Wait for refresh to complete and data to load
-  //       await vscode.window.waitForTimeout(3000);
-
-  //       // Step 12: Check the data tree content for our test analyzer results
-
-  //       // Debug: Let's see what tree sections we have available
-
-  //       const allTreeSections = vscode.window.locator(".pane-header");
-  //       const treeSectionCount = await allTreeSections.count();
-
-  //       if (treeSectionCount > 0) {
-  //         const treeSectionTexts = await allTreeSections.allTextContents();
-  //       }
-
-  //       // Get the data tree using the section title approach (no fallbacks!)
-  //       // We need to target specifically the "Data & Results" section, not "CO2 Assessment"
-
-  //       // Click on the Data & Results header to ensure it's expanded
-  //       const dataResultsHeader = vscode.window
-  //         .locator(".pane-header")
-  //         .filter({ hasText: "Data & Results" });
-  //       await dataResultsHeader.click();
-
-  //       // Debug: Let's examine ALL 3 tree sections to see which one has the analysis results
-
-  //       const allTrees = vscode.window.locator(
-  //         '[id*="workbench.view.extension.carbonara"] .monaco-list, [id*="workbench.view.extension.carbonara"] .tree-explorer-viewlet-tree-view'
-  //       );
-  //       const treeCount = await allTrees.count();
-
-  //       // Examine each tree individually
-  //       for (let i = 0; i < treeCount; i++) {
-  //         const tree = allTrees.nth(i);
-  //         const treeRows = tree.locator(".monaco-list-row");
-  //         const rowCount = await treeRows.count();
-
-  //         if (rowCount > 0) {
-  //           const rowTexts = await treeRows.allTextContents();
-  //         }
-  //       }
-
-  //       // Now try to find the tree with analysis results (not questionnaire data)
-
-  //       let dataTree: Locator | null = null;
-  //       let foundAnalysisTree = false;
-
-  //       for (let i = 0; i < treeCount; i++) {
-  //         const tree = allTrees.nth(i);
-  //         const treeRows = tree.locator(".monaco-list-row");
-  //         const rowCount = await treeRows.count();
-
-  //         if (rowCount > 0) {
-  //           const rowTexts = await treeRows.allTextContents();
-  //           const hasQuestionnaireData = rowTexts.some(
-  //             (text) =>
-  //               text.includes("Project Information") ||
-  //               text.includes("Infrastructure") ||
-  //               text.includes("Development")
-  //           );
-
-  //           const hasAnalysisData = rowTexts.some(
-  //             (text) =>
-  //               text.includes("Test Analysis") ||
-  //               text.includes("test-") ||
-  //               text.includes(".example.com")
-  //           );
-
-  //           if (hasAnalysisData && !hasQuestionnaireData) {
-  //             dataTree = tree;
-  //             foundAnalysisTree = true;
-  //             break;
-  //           }
-  //         }
-  //       }
-
-  //       if (!foundAnalysisTree) {
-  //         dataTree = allTrees.nth(1);
-  //       }
-
-  //       await expect(dataTree!).toBeVisible();
-
-  //       const dataRows = dataTree!.locator(".monaco-list-row");
-  //       const dataRowCount = await dataRows.count();
-
-  //       if (dataRowCount > 0) {
-  //         const dataTexts = await dataRows.allTextContents();
-
-  //         // STRICT CHECK: Look for ACTUAL analysis results, not just tool names
-  //         // We should see analysis data like URLs, scores, timestamps - NOT just tool names
-
-  //         // First, check if we're seeing tools list instead of analysis results
-  //         const isShowingToolsList = dataTexts.some(
-  //           (text) =>
-  //             text.includes("Built-in") ||
-  //             text.includes("Not installed") ||
-  //             text.includes("Installed")
-  //         );
-
-  //         // Look for actual analysis result indicators from our test
-
-  //         dataTexts.forEach((text, i) => {});
-
-  //         const hasTestAnalysisResults = dataTexts.some((text) => {
-  //           const lowerText = text.toLowerCase();
-  //           return (
-  //             // Look for our test analysis group or entries
-  //             lowerText.includes("test analysis") ||
-  //             // Look for any test domain variation (test-site, test-fix, etc.)
-  //             text.match(/test-[^.]+\.example\.com/) ||
-  //             lowerText.includes("test result") ||
-  //             // Look for timestamp patterns (from screenshot: "02/09/2025")
-  //             text.match(/\d{2}\/\d{2}\/\d{4}/)
-  //           );
-  //         });
-
-  //         if (isShowingToolsList && !hasTestAnalysisResults) {
-  //           // FAIL THE TEST: We should see analysis results, not tools
-  //           expect(isShowingToolsList).toBe(false);
-  //           return; // Exit early since we have wrong content
-  //         }
-
-  //         // ASSERTION: Must have actual test analysis results
-  //         if (!hasTestAnalysisResults) {
-  //           const expected = [
-  //             '"Test Analysis" (group name)',
-  //             '"test-*.example.com" (URL pattern)',
-  //             '"test result" (description)',
-  //             '"02/09/2025" (date pattern)',
-  //           ];
-
-  //           const errorMessage = `Expected to find test analysis results in Data & Results tab.
+      // Wait for URL input dialog to appear
+      await vscode.window.waitForTimeout(1000);
+
+      // Look for the input box and enter a test URL
+      const inputBox = vscode.window.locator(
+        'input[placeholder*="https://example.com"], .quick-input-box input'
+      );
+      await expect(inputBox).toBeVisible({ timeout: 5000 });
+
+      const testUrl = "https://test-site.example.com";
+      await inputBox.fill(testUrl);
+
+      // Press Enter to confirm
+      await inputBox.press("Enter");
+
+      // Wait for analysis completion notification
+
+      // Look for the completion notification or wait longer for CLI to finish
+      try {
+        // Wait for either success or failure notification using UI constants
+        const successNotification = vscode.window
+          .locator(SELECTORS.NOTIFICATIONS.TOAST)
+          .filter({ hasText: "analysis completed" });
+        const failureNotification = vscode.window
+          .locator(SELECTORS.NOTIFICATIONS.TOAST)
+          .filter({ hasText: UI_TEXT.NOTIFICATIONS.ANALYSIS_FAILED });
+
+        // Wait up to 10 seconds for one of these notifications
+        await Promise.race([
+          successNotification.waitFor({ timeout: 10000 }),
+          failureNotification.waitFor({ timeout: 10000 }),
+        ]);
+
+        // Check which notification appeared
+        const hasSuccess = await successNotification.isVisible();
+        const hasFailure = await failureNotification.isVisible();
+
+        if (hasSuccess) {
+        } else if (hasFailure) {
+          // FAIL THE TEST: Analysis should succeed for test analyzer
+          expect(hasFailure).toBe(false);
+          return; // Exit early since analysis failed
+        } else {
+        }
+
+        // ASSERTION: Analysis must succeed (no failure notification should be visible)
+        expect(hasFailure).toBe(false);
+      } catch (error) {
+        // Fallback: wait additional time for CLI process to complete
+        await vscode.window.waitForTimeout(3000);
+      }
+
+      // Step 10: Verify analysis results appear in Data Tree
+
+      // Look for the Data & Results section
+      const dataSection = vscode.window
+        .locator(".pane-header")
+        .filter({ hasText: "Data & Results" });
+      await expect(dataSection).toBeVisible();
+
+      // Click on Data & Results section to ensure it's expanded and active
+      await dataSection.click();
+
+      // Step 11: Manually refresh the data tree to ensure latest results are loaded
+
+      // Use F1 to open command palette and search for data refresh
+      await vscode.window.keyboard.press("F1");
+      await vscode.window.waitForTimeout(500);
+
+      await vscode.window.keyboard.type("Carbonara: Refresh Data");
+      await vscode.window.waitForTimeout(500);
+
+      await vscode.window.keyboard.press("Enter");
+
+      // Wait for refresh to complete and data to load
+      await vscode.window.waitForTimeout(3000);
+
+      // Step 12: Check the data tree content for our test analyzer results
+
+      // Debug: Let's see what tree sections we have available
+
+      const allTreeSections = vscode.window.locator(".pane-header");
+      const treeSectionCount = await allTreeSections.count();
+
+      if (treeSectionCount > 0) {
+        const treeSectionTexts = await allTreeSections.allTextContents();
+      }
+
+      // Get the data tree using the section title approach (no fallbacks!)
+      // We need to target specifically the "Data & Results" section, not "CO2 Assessment"
+
+      // Click on the Data & Results header to ensure it's expanded
+      const dataResultsHeader = vscode.window
+        .locator(".pane-header")
+        .filter({ hasText: "Data & Results" });
+      await dataResultsHeader.click();
+
+      // Debug: Let's examine ALL 3 tree sections to see which one has the analysis results
+
+      const allTrees = vscode.window.locator(
+        '[id*="workbench.view.extension.carbonara"] .monaco-list, [id*="workbench.view.extension.carbonara"] .tree-explorer-viewlet-tree-view'
+      );
+      const treeCount = await allTrees.count();
+
+      // Examine each tree individually
+      for (let i = 0; i < treeCount; i++) {
+        const tree = allTrees.nth(i);
+        const treeRows = tree.locator(".monaco-list-row");
+        const rowCount = await treeRows.count();
+
+        if (rowCount > 0) {
+          const rowTexts = await treeRows.allTextContents();
+        }
+      }
+
+      // Now try to find the tree with analysis results (not questionnaire data)
+
+      let dataTree: Locator | null = null;
+      let foundAnalysisTree = false;
+
+      for (let i = 0; i < treeCount; i++) {
+        const tree = allTrees.nth(i);
+        const treeRows = tree.locator(".monaco-list-row");
+        const rowCount = await treeRows.count();
+
+        if (rowCount > 0) {
+          const rowTexts = await treeRows.allTextContents();
+          const hasQuestionnaireData = rowTexts.some(
+            (text) =>
+              text.includes("Project Information") ||
+              text.includes("Infrastructure") ||
+              text.includes("Development")
+          );
+
+          const hasAnalysisData = rowTexts.some(
+            (text) =>
+              text.includes("Test Analysis") ||
+              text.includes("test-") ||
+              text.includes(".example.com")
+          );
+
+          if (hasAnalysisData && !hasQuestionnaireData) {
+            dataTree = tree;
+            foundAnalysisTree = true;
+            break;
+          }
+        }
+      }
+
+      if (!foundAnalysisTree) {
+        dataTree = allTrees.nth(1);
+      }
+
+      await expect(dataTree!).toBeVisible();
+
+      const dataRows = dataTree!.locator(".monaco-list-row");
+      const dataRowCount = await dataRows.count();
+
+      if (dataRowCount > 0) {
+        const dataTexts = await dataRows.allTextContents();
+
+        // STRICT CHECK: Look for ACTUAL analysis results, not just tool names
+        // We should see analysis data like URLs, scores, timestamps - NOT just tool names
+
+        // First, check if we're seeing tools list instead of analysis results
+        const isShowingToolsList = dataTexts.some(
+          (text) =>
+            text.includes("Built-in") ||
+            text.includes("Not installed") ||
+            text.includes("Installed")
+        );
+
+        // Look for actual analysis result indicators from our test
+
+        dataTexts.forEach((text, i) => {});
+
+        const hasTestAnalysisResults = dataTexts.some((text) => {
+          const lowerText = text.toLowerCase();
+          return (
+            // Look for our test analysis group or entries
+            lowerText.includes("test analysis") ||
+            // Look for any test domain variation (test-site, test-fix, etc.)
+            text.match(/test-[^.]+\.example\.com/) ||
+            lowerText.includes("test result") ||
+            // Look for timestamp patterns (from screenshot: "02/09/2025")
+            text.match(/\d{2}\/\d{2}\/\d{4}/)
+          );
+        });
+
+        if (isShowingToolsList && !hasTestAnalysisResults) {
+          // FAIL THE TEST: We should see analysis results, not tools
+          expect(isShowingToolsList).toBe(false);
+          return; // Exit early since we have wrong content
+        }
+
+        // ASSERTION: Must have actual test analysis results
+        if (!hasTestAnalysisResults) {
+          const expected = [
+            '"Test Analysis" (group name)',
+            '"test-*.example.com" (URL pattern)',
+            '"test result" (description)',
+            '"02/09/2025" (date pattern)',
+          ];
+
+          const errorMessage = `Expected to find test analysis results in Data & Results tab.
 
   // Expected one of:
   // ${expected.map((e) => `  - ${e}`).join("\n")}
@@ -610,27 +610,27 @@ test.describe("Carbonara VSCode Extension E2E Tests", () => {
   // Found actual:
   // ${dataTexts.map((text, i) => `  [${i}] "${text}"`).join("\n")}`;
 
-  //           throw new Error(errorMessage);
-  //         }
+          throw new Error(errorMessage);
+        }
 
-  //         expect(hasTestAnalysisResults).toBe(true);
-  //       } else {
-  //         // Check if there's a "No data available" message vs actual empty state
-  //         const noDataMessage = dataTree!.getByText(/No data/i);
-  //         const hasNoDataMessage = await noDataMessage
-  //           .isVisible()
-  //           .catch(() => false);
+        expect(hasTestAnalysisResults).toBe(true);
+      } else {
+        // Check if there's a "No data available" message vs actual empty state
+        const noDataMessage = dataTree!.getByText(/No data/i);
+        const hasNoDataMessage = await noDataMessage
+          .isVisible()
+          .catch(() => false);
 
-  //         if (hasNoDataMessage) {
-  //         } else {
-  //         }
-  //       }
+        if (hasNoDataMessage) {
+        } else {
+        }
+      }
 
-  //       // Wait 10 seconds for manual inspection before closing
+      // Wait 10 seconds for manual inspection before closing
 
-  //       await vscode.window.waitForTimeout(10000);
-  //     } finally {
-  //       await VSCodeLauncher.close(vscode);
-  //     }
-  //   });
+      await vscode.window.waitForTimeout(10000);
+    } finally {
+      await VSCodeLauncher.close(vscode);
+    }
+  });
 });

--- a/plugins/vscode/src/test/e2e/fixtures/with-analysis-data/create-test-data.js
+++ b/plugins/vscode/src/test/e2e/fixtures/with-analysis-data/create-test-data.js
@@ -4,12 +4,20 @@
 const path = require('path');
 const fs = require('fs');
 
-const dbPath = path.join(__dirname, 'carbonara.db');
+// Use .carbonara directory for database storage
+const carbonaraDir = path.join(__dirname, '.carbonara');
+const dbPath = path.join(carbonaraDir, 'carbonara.db');
 
-// Remove existing database
+// Remove existing database and directory
 if (fs.existsSync(dbPath)) {
   fs.unlinkSync(dbPath);
 }
+if (fs.existsSync(carbonaraDir)) {
+  fs.rmSync(carbonaraDir, { recursive: true, force: true });
+}
+
+// Create .carbonara directory
+fs.mkdirSync(carbonaraDir, { recursive: true });
 
 (async () => {
   const initSqlJs = require('sql.js');

--- a/plugins/vscode/src/test/unit/data-tree-provider.test.ts
+++ b/plugins/vscode/src/test/unit/data-tree-provider.test.ts
@@ -375,4 +375,75 @@ suite("DataTreeProvider Unit Tests", () => {
       // Should handle gracefully, not throw
     });
   });
+
+  suite("Refresh Behavior", () => {
+    test("refresh should fire tree data change event", async () => {
+      let eventFired = false;
+      const disposable = provider.onDidChangeTreeData(() => {
+        eventFired = true;
+      });
+
+      await provider.refresh();
+
+      assert.strictEqual(eventFired, true);
+      disposable.dispose();
+    });
+
+    test("refresh should not throw when coreServices is null", async () => {
+      let threwError = false;
+      try {
+        await provider.refresh();
+      } catch (error) {
+        threwError = true;
+      }
+
+      assert.strictEqual(threwError, false);
+    });
+
+    test("refresh should return a Promise", () => {
+      const result = provider.refresh();
+      assert.ok(result instanceof Promise);
+    });
+
+    test("refresh should clear cache when coreServices is null", async () => {
+      // Set up a mock cache
+      (provider as any).cachedItems = [new DataItem("Test", "", vscode.TreeItemCollapsibleState.None, "info")];
+      
+      await provider.refresh();
+      
+      assert.strictEqual((provider as any).cachedItems, null);
+    });
+  });
+
+  suite("Core Services Null Handling", () => {
+    test("getChildren should return array when coreServices is null", async () => {
+      const children = await provider.getChildren();
+      assert.ok(Array.isArray(children));
+    });
+
+    test("getChildren should not throw when coreServices is null", async () => {
+      let threwError = false;
+      try {
+        await provider.getChildren();
+      } catch (error) {
+        threwError = true;
+      }
+
+      assert.strictEqual(threwError, false);
+    });
+
+    test("getChildren should return items with string labels when coreServices is null", async () => {
+      const children = await provider.getChildren();
+      const firstChild = children[0];
+      
+      assert.ok(typeof firstChild.label === "string");
+    });
+
+    test("getChildren should return DataItem instances when coreServices is null", async () => {
+      const children = await provider.getChildren();
+      const firstChild = children[0];
+      
+      assert.ok(firstChild instanceof DataItem);
+    });
+  });
 });


### PR DESCRIPTION
- Fix loadDataForProject to load all assessment data regardless of project existence
- Add reloadDatabase() method to DataService to reload from disk on refresh
- Update refresh() to reload database before loading data
- Fix timeout logic in initializeCoreServices to warn instead of abort
- Add null check for coreServices in loadRootItemsAsync
- Update workspace fixtures to use .carbonara path for database
- Uncomment and enable test analyzer e2e test
- Add unit tests for refresh behavior and null coreServices handling
- Add integration tests for core services initialization and data loading

## Pull Request Checklist

### Legal Requirements
- [ ] I have read and agree to the [Contributor License Agreement](CONTRIBUTING.md#contributor-license-agreement)
- [ ] I understand that by contributing to this project, I grant the Carbonara team a perpetual, irrevocable license to use my contributions under the BSD license, while the public project remains under AGPL-3.0-or-later

### Code Quality
- [ ] My code follows the project's coding style and conventions
- [ ] I have added appropriate tests for my changes
- [ ] All new and existing tests pass
- [ ] I have updated documentation where necessary

### Description
<!-- Provide a brief description of your changes -->

### Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements

### Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] E2E tests (if applicable)

### Additional Notes
<!-- Add any additional notes, concerns, or context about this PR -->
